### PR TITLE
Add task submission/retrieval engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ rel/example_project
 .concrete/DEV_MODE
 .rebar
 /logs/
+/log/

--- a/src/ooh_wee_app.erl
+++ b/src/ooh_wee_app.erl
@@ -10,6 +10,14 @@
 %% ===================================================================
 
 start(_StartType, _StartArgs) ->
+    Servers = application:get_env(ooh_wee, zookeeper_servers, []),
+    ok = case ezk:start_connection(Servers) of
+             {ok, Pid} ->
+                 ok = zk_utils:is_ok_create(ezk:create(Pid, "/ooh_wee", <<>>)),
+                 ok = zk_utils:is_ok_create(ezk:create(Pid, "/ooh_wee/tasks", <<>>));
+             {error, _} = E->
+                 E
+         end,
     ooh_wee_sup:start_link().
 
 stop(_State) ->

--- a/src/ooh_wee_sup.erl
+++ b/src/ooh_wee_sup.erl
@@ -23,5 +23,4 @@ start_link() ->
 %% ===================================================================
 
 init([]) ->
-    {ok, { {one_for_one, 5, 10}, []} }.
-
+    {ok, { {one_for_one, 5, 10}, [?CHILD(ooh_wee_tasks_sup, supervisor)]} }.

--- a/src/ooh_wee_task_launcher.erl
+++ b/src/ooh_wee_task_launcher.erl
@@ -1,0 +1,75 @@
+-module(ooh_wee_task_launcher).
+
+-behaviour(gen_server).
+
+-export([start_link/2]).
+
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-define(SERVER, ?MODULE).
+
+-record(state, {
+          path    :: string(),
+          mod     :: atom(),
+          zkconn  :: pid()
+         }).
+
+
+start_link(Path, Mod) ->
+    NameAtom = list_to_atom(Path),
+    gen_server:start_link({local, NameAtom}, ?MODULE, [Path, Mod], []).
+
+init([Path, Mod]) ->
+    do_init(Path, Mod).
+
+do_init(Path, Mod) ->
+    Servers = application:get_env(ooh_wee, zookeeper_servers, []),
+    case ezk:start_connection(Servers) of
+        {ok, Pid} ->
+            {ok, Tasks} = ezk:ls(Pid, Path, self(), incoming_tasks),
+            [start_module_for_child(Pid, Task, Mod) || Task <- Tasks],
+            {ok, #state{zkconn=Pid, path=Path, mod=Mod}};
+        {error, _} = E ->
+            E
+    end.
+
+handle_call(_Request, _From, State) ->
+    Reply = ok,
+    {reply, Reply, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info({incoming_tasks, WatchMessage}, #state{zkconn=Pid, path=Path, mod=Mod}=State) ->
+    io:format("~p~n", [WatchMessage]),
+    {ok, Tasks} = ezk:ls(Pid, Path, self(), incoming_tasks),
+    [start_module_for_child(Pid, Task, Mod) || Task <- Tasks],
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+start_module_for_child(Pid, Task, Mod) ->
+    TaskPath = task_path(Task),
+    zk_utils:is_ok_create(ezk:create(Pid, "/ooh_wee/assigned", <<>>)),
+    case ezk:create(Pid, TaskPath, atom_to_binary(Mod, latin1)) of
+        {ok, _} ->
+            spawn(fun() ->
+                          %% This should probably make the connection itself
+                          %% and make an ephemeral node.
+                          %% TODO: Re-read ZK recipes
+                          ModState = Mod:init(Task),
+                          Mod:handle_task(ModState)
+                  end),
+            ok;
+        {error, dir_exists} ->
+            ok
+    end.
+
+task_path(Task) when is_binary(Task) ->
+    %% TODO: Make the constituent paths in the supervisor
+    list_to_binary(["/ooh_wee/assigned/", Task]).

--- a/src/ooh_wee_task_launcher.erl
+++ b/src/ooh_wee_task_launcher.erl
@@ -55,18 +55,23 @@ code_change(_OldVsn, State, _Extra) ->
 
 start_module_for_child(Pid, Task, Mod) ->
     TaskPath = task_path(Task),
-    spawn(fun() ->
-                  Servers = application:get_env(ooh_wee, zookeeper_servers, []),
-                  {ok, Pid} = ezk:start_connection(Servers),
-                  zk_utils:is_ok_create(ezk:create(Pid, "/ooh_wee/assigned", <<>>, e)),
-                  case ezk:create(Pid, TaskPath, atom_to_binary(Mod, latin1)) of
-                      {ok, _} ->
-                          ModState = Mod:init(Task),
-                          Mod:handle_task(ModState);
-                      {error, dir_exists} ->
-                          ok
-                  end
-          end).
+    case ezk:exists(Pid, TaskPath) of
+        {ok, _} ->
+            ok;
+        {error, no_dir} ->
+            spawn(fun() ->
+                          Servers = application:get_env(ooh_wee, zookeeper_servers, []),
+                          {ok, Pid} = ezk:start_connection(Servers),
+                          zk_utils:is_ok_create(ezk:create(Pid, "/ooh_wee/assigned", <<>>, e)),
+                          case ezk:create(Pid, TaskPath, atom_to_binary(Mod, latin1)) of
+                              {ok, _} ->
+                                  ModState = Mod:init(Task),
+                                  Mod:handle_task(ModState);
+                              {error, dir_exists} ->
+                                  ok
+                          end
+                  end)
+    end.
 
 task_path(Task) when is_binary(Task) ->
     %% TODO: Make the constituent paths in the supervisor

--- a/src/ooh_wee_tasks.erl
+++ b/src/ooh_wee_tasks.erl
@@ -1,0 +1,16 @@
+-module(ooh_wee_tasks).
+
+
+-export([submit_task/3]).
+-export([handle_tasks/2]).
+
+
+submit_task(Pid, TaskGroup, TaskData) when is_list(TaskGroup) ->
+    TaskPath = "/ooh_wee/tasks/" ++ TaskGroup ++ "/task-",
+    zk_utils:is_ok_create(ezk:create(Pid, "/ooh_wee/tasks/" ++ TaskGroup, <<>>)),
+    ezk:create(Pid, TaskPath, TaskData, s).
+
+handle_tasks(TaskGroup, Mod)
+  when is_list(TaskGroup) andalso is_atom(Mod) ->
+    {ok, _} = ooh_wee_tasks_sup:start_child(TaskGroup, Mod),
+    ok.

--- a/src/ooh_wee_tasks_sup.erl
+++ b/src/ooh_wee_tasks_sup.erl
@@ -1,0 +1,33 @@
+-module(ooh_wee_tasks_sup).
+
+-behaviour(supervisor).
+
+-export([start_link/0]).
+-export([start_child/2]).
+-export([init/1]).
+
+-define(SERVER, ?MODULE).
+
+
+start_link() ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+
+start_child(TaskGroup, Mod) ->
+    Name = "/ooh_wee/tasks/" ++ TaskGroup,
+    supervisor:start_child(?SERVER, [Name, Mod]).
+
+init([]) ->
+    RestartStrategy = simple_one_for_one,
+    MaxRestarts = 1000,
+    MaxSecondsBetweenRestarts = 3600,
+
+    SupFlags = {RestartStrategy, MaxRestarts, MaxSecondsBetweenRestarts},
+
+    Restart = permanent,
+    Shutdown = 2000,
+    Type = worker,
+
+    AChild = {ooh_wee_task_launcher, {ooh_wee_task_launcher, start_link, []},
+              Restart, Shutdown, Type, [ooh_wee_task_launcher]},
+
+    {ok, {SupFlags, [AChild]}}.

--- a/src/ooh_wee_worker.erl
+++ b/src/ooh_wee_worker.erl
@@ -1,0 +1,8 @@
+-module(ooh_wee_worker).
+
+
+-callback init(Task :: term()) ->
+    {ok, State :: term()}.
+
+-callback handle_task(State :: term()) ->
+    {ok, TaskData :: binary()}.

--- a/src/simple_mod.erl
+++ b/src/simple_mod.erl
@@ -1,0 +1,12 @@
+-module(simple_mod).
+
+-export([init/1]).
+-export([handle_task/1]).
+
+-behaviour(ooh_wee_worker).
+
+init(Task) ->
+    io:format("Starting tas: ~p~n", [Task]).
+
+handle_task(_) ->
+    io:format("handle_task~n", []).

--- a/src/zk_utils.erl
+++ b/src/zk_utils.erl
@@ -1,0 +1,9 @@
+-module(zk_utils).
+
+-export([is_ok_create/1]).
+
+
+is_ok_create({ok, _}) ->
+    ok;
+is_ok_create({error, dir_exists}) ->
+    ok.


### PR DESCRIPTION
**_WIP DO NOT MERGE**_

ZooKeeper can easily act as somewhere that you can store pending "tasks" and have those tasks assigned to workers in a safe way with "at-most-once" guarantees.

Given a handler module which implements `ooh_wee_worker` that simply prints: `handle_task` when a new task is received.

```
2> lager:set_loglevel(lager_console_backend, warning).   
ok
3> ooh_wee_tasks:handle_tasks("fooey", simple_mod).
Starting tas: <<"task-0000000012">>
handle_task
ok
4> {ok, P} = ezk:start_connection().               
{ok,<0.85.0>}
5> ooh_wee_tasks:submit_task(P, "fooey", <<"dataz">>).
{"/ooh_wee/tasks/fooey",child_changed,3}
{ok,"/ooh_wee/tasks/fooey/task-0000000013"}
6> Starting tas: <<"task-0000000013">>
handle_task

6> 
6> ooh_wee_tasks:submit_task(P, "fooey", <<"dataz">>).
{"/ooh_wee/tasks/fooey",child_changed,3}
{ok,"/ooh_wee/tasks/fooey/task-0000000014"}
7> Starting tas: <<"task-0000000014">>
handle_task

7> 
7> ooh_wee_tasks:submit_task(P, "fooey", <<"dataz">>).
{"/ooh_wee/tasks/fooey",child_changed,3}
{ok,"/ooh_wee/tasks/fooey/task-0000000015"}
8> Starting tas: <<"task-0000000015">>
handle_task

8> 
8> ooh_wee_tasks:submit_task(P, "fooey", <<"dataz">>).
{"/ooh_wee/tasks/fooey",child_changed,3}
{ok,"/ooh_wee/tasks/fooey/task-0000000016"}
9> Starting tas: <<"task-0000000016">>
handle_task

9> 
9> ooh_wee_tasks:submit_task(P, "fooey", <<"dataz">>).
{"/ooh_wee/tasks/fooey",child_changed,3}
{ok,"/ooh_wee/tasks/fooey/task-0000000017"}
10> Starting tas: <<"task-0000000017">>
handle_task

10> 
10> ooh_wee_tasks:submit_task(P, "fooey", <<"dataz">>).
{"/ooh_wee/tasks/fooey",child_changed,3}
{ok,"/ooh_wee/tasks/fooey/task-0000000018"}
11> Starting tas: <<"task-0000000018">>
handle_task
```

There are lots of TODOs here. E.g. the worker still uses persistent nodes to signify that a job is taken, this should use ephemeral nodes to handle worker failure, there still needs to be a way to return/store a job's final value, e.g. /ooh_wee/tasks/completed/$TASK-ID where this node contains some binary data representing a job's final state.

/cc @puzza007 @aerosol 
